### PR TITLE
Exclude ./build dir from build targets

### DIFF
--- a/dev/package.sh
+++ b/dev/package.sh
@@ -22,6 +22,7 @@ if [ x$SKIP_OSX != x1 ]; then
 		--platform=darwin \
 		--arch=x64 \
 		--version=0.33.6 \
+		--ignore=build \
 		--app-version=$version
 
 	electron-builder \
@@ -43,6 +44,7 @@ if [ x$SKIP_WIN != x1 ]; then
 		--arch=ia32 \
 		--version=0.33.6 \
 		--version-string.ProductName="Chemr" \
+		--ignore=build \
 		--app-version=$version
 
 	electron-builder \


### PR DESCRIPTION
Windows版をビルドしてみたら極端にファイルサイズが大きかったので、Mac用にビルドした生成物がWindows版のビルド対象に含まれているかも