### PR TITLE
Added hidden title bar on OS X

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ var Main = {
 	ready : function () {
 		var self = this;
 
-		self.main = new BrowserWindow({width: 1440, height: 900});
+		self.main = new BrowserWindow({width: 1440, height: 900, 'title-bar-style': 'hidden-inset'});
 		self.main.loadUrl('file://' + __dirname + '/viewer.html');
 		if (config.DEBUG) self.main.openDevTools();
 		self.main.on('closed', function () {

--- a/src/chemr-viewer.html
+++ b/src/chemr-viewer.html
@@ -87,6 +87,10 @@
 			};
 		}
 
+		#container #indexList .inset-shim {
+			height: 10px;
+		}
+
 		#container #indexList paper-icon-item {
 			height: 72px;
 			background: transparent;
@@ -324,6 +328,9 @@
 				<div class="fit layout vertical">
 					<div class="flex relative">
 						<paper-menu class="fit" style="overflow: hidden; direction: rtl; background: transparent">
+							<template is="dom-if" if="{{isOSX}}">
+								<div class="inset-shim"/>
+							</template>
 							<template is="dom-repeat" items="{{selectedIndexers}}">
 								<paper-icon-item data-indexer-id$="{{item.id}}" on-tap="selectIndex" style="direction: ltr">
 									<div class="index-icon" item-icon>

--- a/src/chemr-viewer.js
+++ b/src/chemr-viewer.js
@@ -59,6 +59,11 @@ Polymer({
 		contentFindActive: {
 			type: Boolean,
 			value: false
+		},
+
+		isOSX: {
+			type: Boolean,
+			value: process.platform === 'darwin'
 		}
 	},
 


### PR DESCRIPTION
Electron 0.33 あたりで入った hidden title bar を使ってみました．実装的には darwin の場合に `<template is="dom-if">` で左端のアイコンリストを少し下げる調節を入れています．
タイトルバーが無い分縦幅がより有効に使えるのではないかと思うのですが，どうでしょうか？

![tmp](https://cloud.githubusercontent.com/assets/823277/11035769/b2ea09c2-8737-11e5-984d-7344acfb99a1.gif)
